### PR TITLE
'main' tag as default directly in subscription()

### DIFF
--- a/src/Traits/HasSubscriptions.php
+++ b/src/Traits/HasSubscriptions.php
@@ -62,11 +62,13 @@ trait HasSubscriptions
      *
      * @return PlanSubscription|\Illuminate\Database\Eloquent\Model|MorphMany|null
      */
-    public function subscription(string $subscriptionTag)
+    public function subscription(?string $subscriptionTag = null)
     {
+        $subscriptionTag = $subscriptionTag ?? config('subby.main_subscription_tag');
+
         return $this->subscriptions()->where('tag', $subscriptionTag)->first();
     }
-
+    
     /**
      * Get subscribed plans.
      *


### PR DESCRIPTION
What would you say for this solution? I think it's even more straightforward than `mainSubscription()`?