### PR TITLE
Subscription prorate and proportion methods separately

### DIFF
--- a/src/Models/PlanSubscription.php
+++ b/src/Models/PlanSubscription.php
@@ -655,7 +655,17 @@ class PlanSubscription extends Model
     }
 
     /**
+     * Get subscription duration in days
+     * @return int
+     */
+    public function getTotalDurationInDays(): int
+    {
+        return Carbon::make($this->starts_at)->diffInDays($this->ends_at);
+    }
+
+    /**
      * Days until subscription renews
+     * @return int
      */
     public function getDaysUntilEnds(): int
     {
@@ -664,10 +674,20 @@ class PlanSubscription extends Model
 
     /**
      * Days until subscription trial ends
+     * @return int
      */
     public function getDaysUntilTrialEnds(): int
     {
         return Carbon::now()->diffInDays($this->trial_ends_at);
+    }
+
+    /**
+     * Get the proportion of the remaining billing period
+     * @return float
+     */
+    public function getRemainingPeriodProportion(): float
+    {
+        return round($this->getDaysUntilEnds() / $this->getTotalDurationInDays(), 4);
     }
 
     /**
@@ -676,8 +696,6 @@ class PlanSubscription extends Model
      */
     public function getRemainingPriceProrate(): float
     {
-        $totalDurationInDays = Carbon::make($this->starts_at)->diffInDays($this->ends_at);
-
-        return round($this->price - (($this->price / $totalDurationInDays) * ($totalDurationInDays - $this->getDaysUntilEnds())), 2);
+        return round($this->price * $this->getRemainingPeriodProportion(), 2);
     }
 }


### PR DESCRIPTION
I'd go with separating `getTotalDurationInDays()` and `getRemainingPeriodProportion()` methods as someone may need them independently.

I'm also thinking about the `getDaysUntilEnds()` method name. I think the previous one was better: `getDaysUntilRenewal()`. Or maybe `getDaysUntilBillingEnds()` or just `getDaysUntilEnd()`