### PR TITLE
More generic exception while creating a Plan

### DIFF
--- a/src/Exceptions/PlanSubscriptionTagAlreadyExists.php
+++ b/src/Exceptions/PlanSubscriptionTagAlreadyExists.php
@@ -10,7 +10,7 @@ class PlanSubscriptionTagAlreadyExists extends \InvalidArgumentException
 {
     public function __construct($tag = "", $code = 0, Throwable $previous = null)
     {
-        $message = "A subscription with tag {$tag} is duplicated for this subscriber.";
+        $message = "A subscription with tag '{$tag}' is duplicated for this subscriber.";
         parent::__construct($message, $code, $previous);
     }
 }

--- a/src/Models/Plan.php
+++ b/src/Models/Plan.php
@@ -90,11 +90,11 @@ class Plan extends Model
 
     public static function create(array $attributes = [])
     {
-        if (static::where('tag', $attributes['tag'])->first()) {
-            throw new PlanTagAlreadyExists($attributes['tag']);
+        try {
+            return static::query()->create($attributes);
+        } catch (\Exception $e) {
+            throw new PlanTagAlreadyExists($attributes['tag'] ?? '<unknown tag>');
         }
-
-        return static::query()->create($attributes);
     }
 
     /**


### PR DESCRIPTION
I'd go with this more generic solution - we will catch any other possible problem if creation of the Plan fails.