### PR TITLE
canUseFeature also on trial

### DIFF
--- a/src/Models/PlanSubscription.php
+++ b/src/Models/PlanSubscription.php
@@ -588,8 +588,8 @@ class PlanSubscription extends Model
      */
     public function canUseFeature(string $featureTag): bool
     {
-        // If subscription has ended, cannot use
-        if ($this->hasEnded()) {
+        // If subscription is not active (on trial or on period before end date), cannot use
+        if (!$this->isActive()) {
             return false;
         }
 


### PR DESCRIPTION
Improved the `canUseFeature` method using `isActive` instead of `ended` because `ended` does not take into account the trial period, only subscription. Now subscribers can have their ability to use features checked also on trial.