### PR TITLE
Subscription tag scope

### DIFF
--- a/docs/v4.x/models/plan-subscription-model.md
+++ b/docs/v4.x/models/plan-subscription-model.md
@@ -300,4 +300,7 @@ $subscriptions = PlanSubscription::findEndingPeriod(3)->get();
 
 // Get subscriptions with ended period
 $subscriptions = PlanSubscription::findEndedPeriod()->get();
+
+// Get subscriptions with period ending in 3 days filtered by the subscription tag
+$subscriptions = PlanSubscription::getByTag('company')->findEndingPeriod(3)->get();
 ```

--- a/src/Models/PlanSubscription.php
+++ b/src/Models/PlanSubscription.php
@@ -494,6 +494,19 @@ class PlanSubscription extends Model
     }
 
     /**
+     * Scope subscriptions by tag.
+     *
+     * @param \Illuminate\Database\Eloquent\Builder $builder
+     * @param string $tag
+     *
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopeGetByTag(Builder $builder, string $tag): Builder
+    {
+        return $builder->where('tag', $tag);
+    }
+    
+    /**
      * Set new subscription period.
      *
      * @param string $invoice_interval


### PR DESCRIPTION
We use different subscription tag names for user and companies. This scope helps to filter the ending subscriptions by their tag (eg. to send out different email body to the users / companies)