### PR TITLE
Getting the default subscription for any subscriber

### DIFF
--- a/docs/v4.x/models/plan-subscription-model.md
+++ b/docs/v4.x/models/plan-subscription-model.md
@@ -99,12 +99,13 @@ $user->subscriptions;
 $user->activeSubscriptions;
 ```
 
-## Subscriber's main subscription
+## Subscriber's main or only subscription
 
 Since usually projects work with only one subscription or one primary, you have to set the tag for it in the
 config `main_subscription_tag`.
 
-By default is `main`.
+If your user only has one subscription, `subscription()` will return the only one the subscriber has. If has more, it
+will fall to default. Default is `main`.
 
 ```php
 // config/subby.php
@@ -117,11 +118,8 @@ return [
 Then:
 
 ```php
-// This:
+// This retrieves user's only one subscription or 'main' from config:
 $user->subscription();
-
-// Equals
-$user->subscription('main'); // Or $user->subscription(config('subby.main_subscription_tag'));
 ```
 
 ## Subscription Feature Usage

--- a/src/Traits/HasSubscriptions.php
+++ b/src/Traits/HasSubscriptions.php
@@ -109,8 +109,10 @@ trait HasSubscriptions
      * @return \Illuminate\Database\Eloquent\Model
      * @throws \Exception
      */
-    public function newSubscription(string $tag, Plan $plan, ?string $name = null, ?string $description = null, ?Carbon $startDate = null)
+    public function newSubscription(?string $tag, Plan $plan, ?string $name = null, ?string $description = null, ?Carbon $startDate = null)
     {
+        $tag = $tag ?? config('subby.main_subscription_tag');
+        
         $trial = new Period($plan->trial_interval, $plan->trial_period, $startDate ?? now());
         $period = new Period($plan->invoice_interval, $plan->invoice_period, $trial->getEndDate());
 

--- a/src/Traits/HasSubscriptions.php
+++ b/src/Traits/HasSubscriptions.php
@@ -58,12 +58,24 @@ trait HasSubscriptions
      */
     public function subscription(?string $subscriptionTag = null)
     {
-        $subscription = $this->subscriptions()
-            ->when($subscriptionTag !== null, function ($q) use ($subscriptionTag) {
-                return $q->where('tag', $subscriptionTag);
-            })
-            ->first();
-        
+        if ($subscriptionTag === null) {
+            $count = $this->subscriptions()->count();
+
+            if ($count === 1) {
+                return $this->subscriptions()->first();
+            } elseif ($count === 0) {
+                throw new PlanSubscriptionNotFound($subscriptionTag);
+            }
+        }
+
+        $subscriptionTag = $subscriptionTag ?? config('subby.main_subscription_tag');
+
+        if (!$subscriptionTag) {
+            throw new InvalidArgumentException('Subscription tag not provided and default config is empty.');
+        }
+
+        $subscription = $this->subscriptions()->where('tag', $subscriptionTag)->first();
+
         if (!$subscription) {
             throw new PlanSubscriptionNotFound($subscriptionTag);
         }

--- a/src/Traits/HasSubscriptions.php
+++ b/src/Traits/HasSubscriptions.php
@@ -58,14 +58,12 @@ trait HasSubscriptions
      */
     public function subscription(?string $subscriptionTag = null)
     {
-        $subscriptionTag = $subscriptionTag ?? config('subby.main_subscription_tag');
-
-        if (!$subscriptionTag) {
-            throw new InvalidArgumentException('Subscription tag not provided and default config is empty.');
-        }
-
-        $subscription = $this->subscriptions()->where('tag', $subscriptionTag)->first();
-
+        $subscription = $this->subscriptions()
+            ->when($subscriptionTag !== null, function ($q) use ($subscriptionTag) {
+                return $q->where('tag', $subscriptionTag);
+            })
+            ->first();
+        
         if (!$subscription) {
             throw new PlanSubscriptionNotFound($subscriptionTag);
         }


### PR DESCRIPTION
On second thought and while developing a real project, I'd go with this solution for the default subscription tag. `->subscription()` will work now independently of the tag used for the subscriber. 

As mentioned before, we use different tag names for different types of subscribers. Now `$user->subscription()` and `$company->subscription()` will work universally without a need to find their corresponding subscription tag. And when someone wants to use different tags for the same type of subscriber, they should be always passed explicitly.

In the second commit I used `'subby.main_subscription_tag'` for creating the new subscription.