### PR TITLE
Fix getResetDate

### DIFF
--- a/src/Models/PlanSubscription.php
+++ b/src/Models/PlanSubscription.php
@@ -661,7 +661,7 @@ class PlanSubscription extends Model
      *
      * @return mixed
      */
-    private function getUsageByFeatureTag(string $featureTag)
+    public function getUsageByFeatureTag(string $featureTag)
     {
         return $this->usage()->byFeatureTag($featureTag)->first();
     }

--- a/src/Traits/HasResetDate.php
+++ b/src/Traits/HasResetDate.php
@@ -12,14 +12,18 @@ trait HasResetDate
     /**
      * Get feature's reset date.
      *
-     * @param string $dateFrom
+     * @param Carbon|null $dateFrom
      *
      * @return \Carbon\Carbon
      * @throws \Exception
      */
-    public function getResetDate(Carbon $dateFrom): Carbon
+    public function getResetDate(?Carbon $dateFrom = null): Carbon
     {
-        $period = new Period($this->resettable_interval, $this->resettable_period, $dateFrom ?? now());
+        $today = Carbon::now();
+
+        do {
+            $period = new Period($this->resettable_interval, $this->resettable_period, $dateFrom ?? $today);
+        } while ($period->getEndDate()->lt($today));
 
         return $period->getEndDate();
     }

--- a/tests/Unit/PlanSubscriptionUsageTest.php
+++ b/tests/Unit/PlanSubscriptionUsageTest.php
@@ -23,9 +23,10 @@ class PlanSubscriptionUsageTest extends TestCase
     /**
      * Consume all of a feature and check next period
      */
-    public function testConsumeAllFeatureAndRenewToNextPeriod()
+    public function testConsumeAllFeatureAndMoveToNextPeriod()
     {
         $this->testUser->subscription('main')->recordFeatureUsage('posts_per_social_profile', 30);
+        $this->travelTo($this->testUser->subscription('main')->getFeatureByTag('posts_per_social_profile')->valid_until->addSecond());
         $this->testUser->subscription('main')->renew();
         $this->assertTrue($this->testUser->subscription('main')->canUseFeature('posts_per_social_profile'));
     }

--- a/tests/Unit/PlanSubscriptionUsageTest.php
+++ b/tests/Unit/PlanSubscriptionUsageTest.php
@@ -21,13 +21,23 @@ class PlanSubscriptionUsageTest extends TestCase
     }
 
     /**
-     * Consume all of a feature and check next period
+     * Consume all of a feature and check next period without renewing monthly subscription
      */
-    public function testConsumeAllFeatureAndMoveToNextPeriod()
+    public function testConsumeAllFeatureAndMoveToNextUsagePeriodWithoutRenewal()
     {
         $this->testUser->subscription('main')->recordFeatureUsage('posts_per_social_profile', 30);
-        $this->travelTo($this->testUser->subscription('main')->getFeatureByTag('posts_per_social_profile')->valid_until->addSecond());
+        $this->travelTo($this->testUser->subscription('main')->getUsageByFeatureTag('posts_per_social_profile')->valid_until->addSecond());
+        $this->assertFalse($this->testUser->subscription('main')->canUseFeature('posts_per_social_profile'));
+    }
+
+    /**
+     * Consume all of a feature and check next subscription period
+     */
+    public function testConsumeAllFeatureAndMoveToNextSubscriptionPeriod()
+    {
+        $this->testUser->subscription('main')->recordFeatureUsage('posts_per_social_profile', 30);
         $this->testUser->subscription('main')->renew();
+        $this->travelTo($this->testUser->subscription('main')->starts_at->addSecond());
         $this->assertTrue($this->testUser->subscription('main')->canUseFeature('posts_per_social_profile'));
     }
 


### PR DESCRIPTION
As mentioned here #77 (comment)

If subscriber does not use the app for 1 period, when usage is going to be recorded again. It will be set to next month from the previous period and use one. Subscribers get 1 usage for every period they've been out.

Now function retrieves periods until now.