### PR TITLE
Add fallback plan

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 return [
     'main_subscription_tag' => 'main',
-
+    'fallback_plan_tag' => null,
     // Database Tables
     'tables' => [
         'plans' => 'plans',

--- a/docs/v5.x/install/migrate-v5.md
+++ b/docs/v5.x/install/migrate-v5.md
@@ -8,6 +8,12 @@ In your composer version, require v4.
 "bpuig/laravel-subby": "^5.0",
 ```
 
+## Config
+New lines in config:
+```php 
+'fallback_plan_tag' => null,
+```
+
 ## Migrations
 
 Publish v5 migrations

--- a/docs/v5.x/models/plan-subscription-model.md
+++ b/docs/v5.x/models/plan-subscription-model.md
@@ -305,11 +305,24 @@ To cancel a subscription, simply use the `cancel` method on the user's subscript
 $user->subscription('main')->cancel();
 ```
 
+### Immediately
 By default the subscription will remain active until the end of the period, you may pass `true` to end the
 subscription _immediately_:
 
 ```php
 $user->subscription('main')->cancel(true);
+```
+
+### Fallback plan
+::: tip New in 5.0
+Now you can specify in config a fallback plan
+:::
+If a `fallback_plan_tag` is not `null` in config, when `cancel` is called, subscription will not be canceled but changed
+to fallback plan.
+
+To cancel subscription and ignore fallback, a second parameter is available on `cancel` method:
+```php
+$user->subscription('main')->cancel(false, true);
 ```
 
 ## Uncancel a subscription


### PR DESCRIPTION
## Status
**READY**

## Migrations
NO

## Description
This new feature allows to specify a fallback plan in config. Default behaviour if config is set is that, when canceled, user subscription will have its plan changed instead of canceled. 
Resolves #81 

## Todos
- [x] Tests
- [x] Documentation


## Deploy Notes
It is necessary to add a new line in config.php, see docs.


## Impacted Areas in Application
* `cancel()` method of PlanSubscription behaviour
