### PR TITLE
strict types in CreatePlanSubscriptionFeaturesTable

### DIFF
--- a/database/migrations/create_plan_subscription_features_table.php.stub
+++ b/database/migrations/create_plan_subscription_features_table.php.stub
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;


### PR DESCRIPTION
## Status
**READY**

## Migrations
YES

## Description
Missing `declare(strict_types=1);` in one of migrations

