### PR TITLE
Simplify scheduler

### DIFF
--- a/database/migrations/create_plan_subscription_schedules_table.php.stub
+++ b/database/migrations/create_plan_subscription_schedules_table.php.stub
@@ -20,8 +20,6 @@ class CreatePlanSubscriptionSchedulesTable extends Migration
             $table->unsignedInteger('subscription_id');
             $table->unsignedInteger('plan_id');
             $table->string('service')->default('default');
-            $table->smallInteger('tries')->default(3);
-            $table->integer('timeout')->default(120);
             $table->timestamp('scheduled_at')->nullable();
             $table->timestamp('failed_at')->nullable();
             $table->timestamp('succeeded_at')->nullable();

--- a/docs/v5.x/models/plan-subscription-schedule-model.md
+++ b/docs/v5.x/models/plan-subscription-schedule-model.md
@@ -4,6 +4,7 @@ There are some things different to  [Laravel Subby Schedule](https://github.com/
 rare event that you were using the package, please review the docs.
 - Limits were removed
 - Methods were renamed: `usingService` was `service`
+- Columns `tries` and `timeout` are now constants in service
 - IsScheduled trait no longer exists
 :::
 
@@ -32,14 +33,11 @@ $user->subscription('main')->toPlan($this->testPlanPro)->onDate($date)->setSched
 ```
 
 You can set other options like:
-
 - `usingService()`: References [service](#services) name in config file.
-- `timeout()`: Timeout for the job that will launch the service.
-- `tries()`: Number of tries job will be attempted
 
 ```php
 $date = Carbon::now()->add(15, 'day');
-$user->subscription('main')->toPlan($this->testPlanPro)->onDate($date)->usingService('default')->tries(2)->timeout(200)->setSchedule();
+$user->subscription('main')->toPlan($this->testPlanPro)->onDate($date)->usingService('default')->setSchedule();
 ```
 
 ## Scopes
@@ -111,6 +109,15 @@ class ScheduleService implements PlanSubscriptionScheduleService
         $this->success = true;
     }
 }
+```
+
+### Service options
+
+The defined options for the job that will call the service will be defined in constants the service file. By default, 
+PlanSubscriptionSchedule contract has this settings.
+```php
+const TRIES=3; // Number of tries job will be attempted
+const TIMEOUT=120; // Timeout for the job that will launch the service.
 ```
 
 ## Jobs

--- a/src/Contracts/PlanSubscriptionScheduleService.php
+++ b/src/Contracts/PlanSubscriptionScheduleService.php
@@ -6,6 +6,9 @@ namespace Bpuig\Subby\Contracts;
 
 interface PlanSubscriptionScheduleService
 {
+    const TRIES=3;
+    const TIMEOUT=120;
+
     /**
      * PlanSubscriptionScheduleService constructor.
      * @param $planSubscriptionSchedule

--- a/src/Jobs/SubscriptionScheduleProcessJob.php
+++ b/src/Jobs/SubscriptionScheduleProcessJob.php
@@ -19,7 +19,7 @@ class SubscriptionScheduleProcessJob implements ShouldQueue
      *
      * @var int
      */
-    public $tries = 3;
+    public $tries = 1;
 
     /**
      * The number of seconds the job can run before timing out.
@@ -48,9 +48,7 @@ class SubscriptionScheduleProcessJob implements ShouldQueue
 
         $this->planSubscriptionSchedule = $planSubscriptionSchedule;
 
-        // Set options
-        $this->tries = $this->planSubscriptionSchedule->tries;
-        $this->timeout = $this->planSubscriptionSchedule->timeout;
+        // Retrieve service from config
         $this->scheduleServiceConfig = 'subby.services.schedule.' . $this->planSubscriptionSchedule->service;
 
         // Check if service exists in config file
@@ -60,6 +58,10 @@ class SubscriptionScheduleProcessJob implements ShouldQueue
 
         // Create instance of selected service and inject plan's subscription schedule
         $this->scheduleService = app()->make(config($this->scheduleServiceConfig), ['planSubscriptionSchedule' => $this->planSubscriptionSchedule]);
+
+        // Set options from service constants
+        $this->tries = $this->scheduleService::TRIES;
+        $this->timeout = $this->scheduleService::TIMEOUT;
     }
 
     // Avoid overlapping jobs, so it is not paid double, etc.

--- a/src/Models/PlanSubscriptionSchedule.php
+++ b/src/Models/PlanSubscriptionSchedule.php
@@ -13,8 +13,6 @@ use Illuminate\Database\Eloquent\Model;
  * @property integer $subscription_id
  * @property integer $plan_id;
  * @property string $service
- * @property integer $tries
- * @property integer $timeout
  * @property \Carbon\Carbon|null $scheduled_at
  * @property \Carbon\Carbon|null $failed_at
  * @property \Carbon\Carbon|null $succeeded_at
@@ -30,8 +28,6 @@ class PlanSubscriptionSchedule extends Model
         'subscription_id',
         'plan_id',
         'service',
-        'tries',
-        'timeout',
         'scheduled_at'
     ];
 
@@ -42,8 +38,6 @@ class PlanSubscriptionSchedule extends Model
         'subscription_id' => 'integer',
         'plan_id' => 'integer',
         'service' => 'string',
-        'tries' => 'integer',
-        'timeout' => 'integer',
         'scheduled_at' => 'datetime',
         'failed_at' => 'datetime',
         'succeeded_at' => 'datetime'
@@ -71,8 +65,6 @@ class PlanSubscriptionSchedule extends Model
             'subscription_id' => 'required|integer|exists:' . config('subby.tables.plan_subscriptions') . ',id',
             'plan_id' => 'required|integer|exists:' . config('subby.tables.plans') . ',id',
             'service' => 'string',
-            'tries' => 'integer',
-            'timeout' => 'integer',
             'scheduled_at' => 'date'
         ];
     }

--- a/src/Traits/HasSchedules.php
+++ b/src/Traits/HasSchedules.php
@@ -30,18 +30,6 @@ trait HasSchedules
     private $scheduledService = 'default';
 
     /**
-     * Tries for schedule job
-     * @var int
-     */
-    private $scheduledTries = 1;
-
-    /**
-     * Timeout for job
-     * @var int
-     */
-    private $scheduledTimeout = 120;
-
-    /**
      * Method of subscription change creation / update
      * @var string
      */
@@ -84,32 +72,6 @@ trait HasSchedules
     }
 
     /**
-     * Timeout for the job
-     *
-     * @param int $seconds
-     * @return $this
-     */
-    public function timeout(int $seconds): self
-    {
-        $this->scheduledTimeout = $seconds;
-
-        return $this;
-    }
-
-    /**
-     * Tries for the job
-     *
-     * @param int $number
-     * @return $this
-     */
-    public function tries(int $number): self
-    {
-        $this->scheduledTries = $number;
-
-        return $this;
-    }
-
-    /**
      * Schedule to time
      *
      * @param Carbon $date
@@ -136,8 +98,6 @@ trait HasSchedules
             'plan_id' => $this->scheduledPlan->id,
             'subscription_id' => $this->id,
             'service' => $this->scheduledService,
-            'tries' => $this->scheduledTries,
-            'timeout' => $this->scheduledTimeout,
             'scheduled_at' => $this->scheduledDate
         ];
 

--- a/tests/Unit/PlanSubscriptionScheduleTest.php
+++ b/tests/Unit/PlanSubscriptionScheduleTest.php
@@ -128,7 +128,7 @@ class PlanSubscriptionScheduleTest extends TestCase
     public function testSuccessfulJob()
     {
         $date = Carbon::now()->add(10, 'day');
-        $this->testUser->subscription('main')->toPlan($this->testPlanPro)->usingService('success')->timeout(200)->tries(1)->onDate($date)->setSchedule();
+        $this->testUser->subscription('main')->toPlan($this->testPlanPro)->usingService('success')->onDate($date)->setSchedule();
 
         $this->travelTo($date->add(5, 'second'));
 
@@ -151,7 +151,7 @@ class PlanSubscriptionScheduleTest extends TestCase
     public function testFailedJob()
     {
         $date = Carbon::now()->add(10, 'day');
-        $this->testUser->subscription('main')->toPlan($this->testPlanPro)->usingService('fail')->timeout(200)->tries(1)->onDate($date)->setSchedule();
+        $this->testUser->subscription('main')->toPlan($this->testPlanPro)->usingService('fail')->onDate($date)->setSchedule();
 
         $this->travelTo($date->add(5, 'second'));
 
@@ -179,7 +179,7 @@ class PlanSubscriptionScheduleTest extends TestCase
         while ($i <= 10) {
             $date->add(1, 'day');
             $plan = ($i % 2 === 0) ? $this->testPlanPro : $this->testPlanBasic;
-            $this->testUser->subscription('main')->toPlan($plan)->usingService('success')->timeout(200)->tries(1)->onDate($date)->setSchedule();
+            $this->testUser->subscription('main')->toPlan($plan)->usingService('success')->onDate($date)->setSchedule();
             $i++;
         }
 


### PR DESCRIPTION
## Status
**READY**

## Migrations
YES

## Description
This pull removes two columns that can be very redundant and replaces them in a per service constants.

## Todos
- [x] Tests
- [x] Documentation


## Deploy Notes
Two columns from schedules table are removed and set into constants on service contract.


## Impacted Areas in Application
* Plan Subscription Schedule
