### PR TITLE
New grace period methods

### DIFF
--- a/docs/v5.x/models/plan-subscription-model.md
+++ b/docs/v5.x/models/plan-subscription-model.md
@@ -99,6 +99,7 @@ $user->subscription('main')->getGraceEndDate(); // Returns grace end date
 $user->subscription('main')->getGraceTotalDurationIn('day'); // Returns number of days grace lasts
 $user->subscription('main')->getGracePeriodUsageIn('day'); // Returns number of days of grace consumed
 $user->subscription('main')->getGracePeriodRemainingUsageIn('day'); // Returns number of days until subscription grace ends
+$user->subscription('main')->hasStartedGrace(); // Returns boolean indicating if grace period is over
 $user->subscription('main')->hasEndedGrace(); // Returns boolean indicating if grace period is over
 ```
 

--- a/src/Traits/HasGracePeriodUsage.php
+++ b/src/Traits/HasGracePeriodUsage.php
@@ -61,6 +61,16 @@ trait HasGracePeriodUsage
     }
 
     /**
+     * Check if entity has started grace
+     *
+     * @return bool
+     */
+    public function hasStartedGrace(): bool
+    {
+        return $this->getGraceStartDate() && \Carbon\Carbon::now()->gt($this->getGraceStartDate());
+    }
+
+    /**
      * Check if entity has ended grace
      *
      * @return bool
@@ -68,5 +78,13 @@ trait HasGracePeriodUsage
     public function hasEndedGrace(): bool
     {
         return !$this->getGraceStartDate() || \Carbon\Carbon::now()->gt($this->getGraceEndDate());
+    }
+
+    /**
+     * Check if entity is in grace period
+     * @return bool
+     */
+    public function isInGrace() {
+        return $this->hasStartedGrace() && !$this->hasEndedGrace();
     }
 }

--- a/tests/Unit/PlanGraceTest.php
+++ b/tests/Unit/PlanGraceTest.php
@@ -62,6 +62,9 @@ class PlanGraceTest extends TestCase
         // Travel one second after subscription ends
         $this->travelTo($user->subscription('grace')->ends_at->addSecond());
         $this->assertTrue($user->subscription('grace')->isActive());
+        $this->assertTrue($user->subscription('grace')->hasStartedGrace());
+        $this->assertTrue($user->subscription('grace')->isInGrace());
+        $this->assertFalse($user->subscription('grace')->hasEndedGrace());
     }
 
     /**
@@ -78,5 +81,8 @@ class PlanGraceTest extends TestCase
         // Travel one second after period ends
         $this->travelTo($graceSubscription->ends_at->add($graceSubscription->grace_period, $graceSubscription->grace_interval)->addSecond());
         $this->assertFalse($graceSubscription->isActive());
+        $this->assertTrue($user->subscription('grace')->hasStartedGrace());
+        $this->assertFalse($user->subscription('grace')->isInGrace());
+        $this->assertTrue($user->subscription('grace')->hasEndedGrace());
     }
 }


### PR DESCRIPTION
## Status
**READY**

## Migrations
NO

## Description
Add methods suggested in #102 .
Now `hasStartedGrace()` and `isInGrace()` are available.

## Todos
- [x] Tests
- [x] Documentation


## Deploy Notes
None.


## Impacted Areas in Application
* Plan Subscription
