### PR TITLE
Plan combinations (countries, periods...)

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -8,6 +8,7 @@ return [
     // Database Tables
     'tables' => [
         'plans' => 'plans',
+        'plan_combinations' => 'plan_combinations',
         'plan_features' => 'plan_features',
         'plan_subscriptions' => 'plan_subscriptions',
         'plan_subscription_features' => 'plan_subscription_features',
@@ -18,6 +19,7 @@ return [
     // Models
     'models' => [
         'plan' => \Bpuig\Subby\Models\Plan::class,
+        'plan_combinations' => \Bpuig\Subby\Models\PlanCombination::class,
         'plan_feature' => \Bpuig\Subby\Models\PlanFeature::class,
         'plan_subscription' => \Bpuig\Subby\Models\PlanSubscription::class,
         'plan_subscription_feature' => \Bpuig\Subby\Models\PlanSubscriptionFeature::class,

--- a/database/migrations/create_plan_combinations_table.php
+++ b/database/migrations/create_plan_combinations_table.php
@@ -24,7 +24,9 @@ return new class extends Migration {
             $table->string('invoice_interval')->default('month');
             $table->timestamps();
 
-            $table->unique(['country', 'currency', 'invoice_period', 'invoice_interval']);
+            $table->unique(['country', 'currency', 'invoice_period', 'invoice_interval'], 'unique_plan_combination');
+
+            $table->foreign('plan_id', 'plan_id_fk')->references('id')->on(config('subby.tables.plans'))->onDelete('cascade')->onUpdate('cascade');
         });
     }
 

--- a/database/migrations/create_plan_combinations_table.php
+++ b/database/migrations/create_plan_combinations_table.php
@@ -14,6 +14,7 @@ return new class extends Migration {
     {
         Schema::create('plan_combinations', function (Blueprint $table) {
             $table->id();
+            $table->unsignedInteger('plan_id')->nullable();
             $table->string('tag')->unique();
             $table->char('country', 3);
             $table->char('currency', 3);

--- a/database/migrations/create_plan_combinations_table.php
+++ b/database/migrations/create_plan_combinations_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('plan_combinations', function (Blueprint $table) {
+            $table->id();
+            $table->string('tag')->unique();
+            $table->char('country', 3);
+            $table->char('currency', 3);
+            $table->decimal('price')->default('0.00');
+            $table->decimal('signup_fee')->default('0.00');
+            $table->unsignedSmallInteger('invoice_period')->default(1);
+            $table->string('invoice_interval')->default('month');
+            $table->timestamps();
+
+            $table->unique(['country', 'currency', 'invoice_period', 'invoice_interval']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('plan_combinations');
+    }
+};

--- a/database/migrations/create_plan_subscription_schedules_table.php
+++ b/database/migrations/create_plan_subscription_schedules_table.php
@@ -18,15 +18,14 @@ return new class extends Migration
         Schema::create(config('subby.tables.plan_subscription_schedules'), function (Blueprint $table) {
             $table->increments('id');
             $table->unsignedInteger('subscription_id');
-            $table->unsignedInteger('plan_id');
+            $table->morphs('scheduleable');
             $table->timestamp('scheduled_at')->nullable();
             $table->timestamp('failed_at')->nullable();
             $table->timestamp('succeeded_at')->nullable();
 
-            $table->unique(['subscription_id', 'plan_id', 'scheduled_at'], 'unique_plan_subscription_keys');
+            $table->unique(['subscription_id', 'scheduleable_type', 'scheduleable_id', 'scheduled_at'], 'unique_plan_subscription_keys');
 
             $table->foreign('subscription_id', 'plan_subscription_fk')->references('id')->on(config('subby.tables.plan_subscriptions'))->onDelete('cascade')->onUpdate('cascade');
-            $table->foreign('plan_id', 'plan_id_fk')->references('id')->on(config('subby.tables.plans'))->onDelete('cascade')->onUpdate('cascade');
         });
     }
 

--- a/database/migrations/dev/alter_plan_subscription_schedules_table.php
+++ b/database/migrations/dev/alter_plan_subscription_schedules_table.php
@@ -16,7 +16,20 @@ return new class extends Migration {
     public function up(): void
     {
         Schema::table(config('subby.tables.plan_subscription_schedules'), function (Blueprint $table) {
-            $table->dropColumn('service');
+            $table->morphs('scheduleable', 'scheduleable');
+            $table->dropForeign('plan_id_fk');
+            $table->dropForeign('plan_subscription_fk');
+            $table->dropUnique('unique_plan_subscription_keys');
+        });
+
+        app(config('subby.models.plan_subscription_schedule'))::query()->update([
+            'scheduleable_type' => config('subby.models.plan'),
+            'scheduleable_id' => \DB::raw('plan_id')
+        ]);
+
+        Schema::table(config('subby.tables.plan_subscription_schedules'), function (Blueprint $table) {
+            $table->dropColumn(['service', 'plan_id']);
+            $table->unique(['subscription_id', 'scheduleable_type', 'scheduleable_id', 'scheduled_at'], 'unique_plan_subscription_keys');
         });
     }
 
@@ -28,7 +41,19 @@ return new class extends Migration {
     public function down(): void
     {
         Schema::table(config('subby.tables.plan_subscription_schedules'), function (Blueprint $table) {
+            $table->unsignedInteger('plan_id')->after('subscription_id');
             $table->string('service')->default('default')->after('plan_id');
+            $table->dropUnique('unique_plan_subscription_keys');
+        });
+
+        app(config('subby.models.plan_subscription_schedule'))::update([
+            'plan_id' => \DB::raw('scheduleable_id')
+        ]);
+
+        Schema::table(config('subby.tables.plan_subscription_schedules'), function (Blueprint $table) {
+            $table->dropMorphs('scheduleable');
+            $table->unique(['subscription_id', 'plan_id', 'scheduled_at'], 'unique_plan_subscription_keys');
+            $table->foreign('plan_id', 'plan_id_fk')->references('id')->on(config('subby.tables.plans'))->onDelete('cascade')->onUpdate('cascade');
         });
     }
 };

--- a/docs/.vuepress/sidebar/dev.js
+++ b/docs/.vuepress/sidebar/dev.js
@@ -16,6 +16,7 @@ var sidebar = [
         children: [
             ['models/', 'Models'],
             ['models/plan-model.md', 'Plan Model'],
+            ['models/plan-combination-model.md', 'Plan Combination Model'],
             ['models/plan-feature-model.md', 'Plan Feature Model'],
             ['models/plan-subscription-model.md', 'Plan Subscription Model'],
             ['models/plan-subscription-feature-model.md', 'Plan Subscription Feature Model'],

--- a/docs/dev/install/migrate-dev.md
+++ b/docs/dev/install/migrate-dev.md
@@ -12,7 +12,23 @@ In your composer version, require `dev-main` version.
 
 ### New lines in config
 
-`'services'` now look should like this:
+Added `plan_combinations` under `tables` and models:
+
+```php
+    'tables' => [
+        ...
+        'plan_combinations' => 'plan_combinations',
+        ...
+    ],
+    // Models
+    'models' => [
+        ...
+        'plan_combinations' => \Bpuig\Subby\Models\PlanCombination::class,
+    ...
+    ]
+```
+
+Added `payment_methods`, `'services'` now look should like this:
 
 ```php 
 'services' => [

--- a/docs/dev/models/README.md
+++ b/docs/dev/models/README.md
@@ -4,6 +4,7 @@
 
 ```php
 Bpuig\Subby\Models\Plan;
+Bpuig\Subby\Models\PlanCombination;
 Bpuig\Subby\Models\PlanFeature;
 Bpuig\Subby\Models\PlanSubscription;
 Bpuig\Subby\Models\PlanSubscriptionFeature;

--- a/docs/dev/models/plan-combination-model.md
+++ b/docs/dev/models/plan-combination-model.md
@@ -48,3 +48,13 @@ $planCombination = $plan->combinations()->where('country', 'ESP')
 $planCombination->plan;
 
 ```
+
+## Subscribe to plan combination
+
+See [Create a Subscription](plan-subscription-model.md#create-a-subscription) and use a `PlanCombination` instead of a
+`Plan`.
+
+## Change subscription's plan to plan combination
+
+See [Create a Subscription](plan-subscription-model.md#change-its-plan) and use a `PlanCombination` instead of a
+`Plan`.

--- a/docs/dev/models/plan-combination-model.md
+++ b/docs/dev/models/plan-combination-model.md
@@ -51,10 +51,14 @@ $planCombination->plan;
 
 ## Subscribe to plan combination
 
-See [Create a Subscription](plan-subscription-model.md#create-a-subscription) and use a `PlanCombination` instead of a
+See [create a Subscription](plan-subscription-model.md#create-a-subscription) and use a `PlanCombination` instead of a
 `Plan`.
 
 ## Change subscription's plan to plan combination
 
-See [Create a Subscription](plan-subscription-model.md#change-its-plan) and use a `PlanCombination` instead of a
+See [change its plan](plan-subscription-model.md#change-its-plan) and use a `PlanCombination` instead of a `Plan`.
+
+## Schedule subscription's plan change to plan combination
+
+See [create schedule](plan-subscription-schedule-model.md#create-schedule) and use a `PlanCombination` instead of a
 `Plan`.

--- a/docs/dev/models/plan-combination-model.md
+++ b/docs/dev/models/plan-combination-model.md
@@ -2,7 +2,8 @@
 
 [[toc]]
 
-With this model you define your plan combinations. You can have multiple prices and intervals per currency, country, etc.
+With this model you define your plan combinations. You can have multiple prices and intervals per currency, country,
+etc.
 
 ## Create a Plan Combination
 
@@ -33,7 +34,10 @@ $planCombination = PlanCombination::find(1);
 $planCombination = PlanCombination::getByTag('basic-es-eur-1-year');
 
 // Or do your own query
-$planCombination = PlanCombination::where('country', 'ES')
+$plan = Plan::getByTag('basic');
+
+$planCombination = $plan->combinations()
+                                        ->where('country', 'ES')
                                         ->where('currency', 'EUR')
                                         ->where('invoice_period', 1)
                                         ->where('invoice_interval', 'year')

--- a/docs/dev/models/plan-combination-model.md
+++ b/docs/dev/models/plan-combination-model.md
@@ -7,6 +7,8 @@ etc.
 
 ## Create a Plan Combination
 
+Combinations must be unique for `country`, `currency`, `invoice_period` and `invoice_interval`.
+
 ```php
 use Bpuig\Subby\Models\Plan;
 use Bpuig\Subby\Models\PlanCombination;
@@ -15,7 +17,7 @@ $plan = Plan::getByTag('basic');
 
 $plan->combinations()->create([
     'tag' => 'basic-es-eur-1-year'
-    'country' => 'ES',
+    'country' => 'ESP',
     'currency' => 'EUR',
     'price' => 99.99,
     'invoice_period' => 1,
@@ -36,8 +38,7 @@ $planCombination = PlanCombination::getByTag('basic-es-eur-1-year');
 // Or do your own query
 $plan = Plan::getByTag('basic');
 
-$planCombination = $plan->combinations()
-                                        ->where('country', 'ES')
+$planCombination = $plan->combinations()->where('country', 'ESP')
                                         ->where('currency', 'EUR')
                                         ->where('invoice_period', 1)
                                         ->where('invoice_interval', 'year')

--- a/docs/dev/models/plan-combination-model.md
+++ b/docs/dev/models/plan-combination-model.md
@@ -1,0 +1,45 @@
+# Plan Combination Model
+
+[[toc]]
+
+With this model you define your plan combinations. You can have multiple prices and intervals per currency, country, etc.
+
+## Create a Plan Combination
+
+```php
+use Bpuig\Subby\Models\Plan;
+use Bpuig\Subby\Models\PlanCombination;
+
+$plan = Plan::getByTag('basic');
+
+$plan->combinations()->create([
+    'tag' => 'basic-es-eur-1-year'
+    'country' => 'ES',
+    'currency' => 'EUR',
+    'price' => 99.99,
+    'invoice_period' => 1,
+    'invoice_interval' => 'year',
+]);
+```
+
+## Get Plan Combination details
+
+You can query the plan combination for further details as follows:
+
+```php
+$planCombination = PlanCombination::find(1);
+
+// Or querying by tag
+$planCombination = PlanCombination::getByTag('basic-es-eur-1-year');
+
+// Or do your own query
+$planCombination = PlanCombination::where('country', 'ES')
+                                        ->where('currency', 'EUR')
+                                        ->where('invoice_period', 1)
+                                        ->where('invoice_interval', 'year')
+                                        ->first();
+
+// Get parent plan                
+$planCombination->plan;
+
+```

--- a/docs/dev/models/plan-model.md
+++ b/docs/dev/models/plan-model.md
@@ -43,6 +43,9 @@ $plan->features;
 // Get all plan subscriptions
 $plan->subscriptions;
 
+// Get all plan combinations
+$plan->combinations;
+
 // Check if the plan is free
 $plan->isFree();
 

--- a/docs/dev/models/plan-subscription-model.md
+++ b/docs/dev/models/plan-subscription-model.md
@@ -3,7 +3,8 @@
 [[toc]]
 
 ## Create a Subscription
-::: tip New in v6.0 
+::: tip New in v6.0
+`newSubscription` accepts a `PlanCombination` as second argument
 `newSubscription` accepts sixth argument: Payment Method
 :::
 You can subscribe a user (or any model correctly traited) to a plan by using the `newSubscription()` function available
@@ -22,16 +23,15 @@ are "frozen" unless
 $user = User::find(1);
 $plan = Plan::find(1);
 
-$user->newSubscription('main', $plan, 'Main subscription', 'Customer main subscription', 'free');
+$user->newSubscription(
+            'main', // identifier tag of the subscription. If your application offers a single subscription, you might call this 'main' or 'primary'
+             $plan, // Plan or PlanCombination instance your subscriber is subscribing to
+             'Main subscription', // Human-readable name for your subscription
+             'Customer main subscription', // Description
+             null, // Start date for the subscription, defaults to now()
+             'free' // Payment method service defined in config
+             );
 ```
-
-- First argument passed to `newSubscription` method should be the identifier tag of the subscription. If your
-  application offers a single subscription, you might call this `main` or `primary`.
-- Second argument is the plan instance your subscriber is subscribing to.
-- Third argument is a human-readable name for your subscription.
-- Fourth argument is a description.
-- Fifth argument is a start date for the subscription.
-- Sixth argument is payment method service defined in config.  <Badge text="new in 6.0" type="tip"/>
 
 ## Change its Plan
 

--- a/docs/dev/models/plan-subscription-model.md
+++ b/docs/dev/models/plan-subscription-model.md
@@ -35,7 +35,7 @@ $user->newSubscription(
 
 ## Change its Plan
 
-You can change subscription related plan easily as follows:
+You can change subscription related plan easily as follows, method accepts either `Plan` or `PlanCombination`:
 
 ```php
 $plan = Plan::find(2);
@@ -78,19 +78,24 @@ $subscription->save();
 
 ### Revert custom subscription changes (resynchronize to plan)
 
-You can revert changes made to subscription with function `syncPlan`.
+You can revert changes made to subscription with function `syncPlan`. Be careful if you are using a `PlanCombination`,
+synchronizing without specifying a plan will synchronize subscription with parent plan.
 
 ```php 
-// Synchronize price, invoicing and tier with related plan
+// Synchronize price, invoicing and tier with parent plan
 $user->subscription('main')->syncPlan();
 
-// Synchronize plan and also features
+// Synchronize with parent plan and also features
 $user->subscription('main')->syncPlan(null, true, true);
+
 ```
 
-`syncPlan()` accepts 3 parameters. First parameter is a `Plan`, if you want to synchronize with current plan
-(default behaviour), set to `null`. Second is `bool` for synchronizing also invoicing details (period and interval),
-default behaviour is to synchronize `true`. The third one is `bool` to also synchronize features.
+`syncPlan()` accepts 3 parameters. 
+- First parameter is a `Plan`, if you want to synchronize with current plan
+(default behaviour), set to `null`. 
+- Second is `bool` for synchronizing also invoicing details (period and interval),
+default behaviour is to synchronize `true`. 
+- Third one is `bool` to also synchronize features.
 
 ## Grace
 

--- a/docs/dev/models/plan-subscription-schedule-model.md
+++ b/docs/dev/models/plan-subscription-schedule-model.md
@@ -7,7 +7,7 @@ schedule your subscription plan changes.
 
 ## What it does
 
-- Plan Subscription is scheduled to change to another plan at a certain date in the future.
+- Plan Subscription is scheduled to change to another plan or plan combination at a certain date in the future.
     * In this schedule you specify date and which service will be executed before the change.
     * You can also set a timeout and tries for the job.
 - A job is added in your app schedule
@@ -26,7 +26,10 @@ You can schedule a change in your user subscription like this:
 
 ```php
 $date = Carbon::now()->add(15, 'day');
-$user->subscription('main')->toPlan($this->testPlanPro)->onDate($date)->setSchedule();
+
+$proPlan = Plan::findByTag('pro-plan');
+
+$user->subscription('main')->toPlan($proPlan)->onDate($date)->setSchedule();
 ```
 
 ## Scopes

--- a/src/Jobs/SubscriptionSchedulePaymentJob.php
+++ b/src/Jobs/SubscriptionSchedulePaymentJob.php
@@ -62,8 +62,8 @@ class SubscriptionSchedulePaymentJob implements ShouldQueue
     {
         $this->service
             ->schedule($this->planSubscriptionSchedule)
-            ->amount($this->planSubscriptionSchedule->plan->price)
-            ->currency($this->planSubscriptionSchedule->plan->currency)
+            ->amount($this->planSubscriptionSchedule->scheduleable->price)
+            ->currency($this->planSubscriptionSchedule->scheduleable->currency)
             ->execute();
     }
 }

--- a/src/Models/Plan.php
+++ b/src/Models/Plan.php
@@ -121,6 +121,16 @@ class Plan extends Model
     }
 
     /**
+     * The plan may have many combinations.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany
+     */
+    public function combinations(): HasMany
+    {
+        return $this->hasMany(config('subby.models.plan_combinations'), 'plan_id', 'id');
+    }
+
+    /**
      * The plan may have many features.
      *
      * @return \Illuminate\Database\Eloquent\Relations\HasMany

--- a/src/Models/Plan.php
+++ b/src/Models/Plan.php
@@ -127,7 +127,7 @@ class Plan extends Model
      */
     public function combinations(): HasMany
     {
-        return $this->hasMany(config('subby.models.plan_combinations'), 'plan_id', 'id');
+        return $this->hasMany(config('subby.models.plan_combination'), 'plan_id', 'id');
     }
 
     /**

--- a/src/Models/Plan.php
+++ b/src/Models/Plan.php
@@ -10,6 +10,7 @@ use Bpuig\Subby\Traits\HasGracePeriod;
 use Bpuig\Subby\Traits\HasPricing;
 use Bpuig\Subby\Traits\HasSubscriptionPeriod;
 use Bpuig\Subby\Traits\HasTrialPeriod;
+use Bpuig\Subby\Traits\MorphsSchedules;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
@@ -20,7 +21,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
  */
 class Plan extends Model
 {
-    use SoftDeletes, HasFeatures, HasPricing, HasTrialPeriod, HasSubscriptionPeriod, HasGracePeriod;
+    use SoftDeletes, HasFeatures, HasPricing, HasTrialPeriod, HasSubscriptionPeriod, HasGracePeriod, MorphsSchedules;
 
     /**
      * {@inheritdoc}

--- a/src/Models/PlanCombination.php
+++ b/src/Models/PlanCombination.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Bpuig\Subby\Models;
 
 use Bpuig\Subby\Traits\BelongsToPlan;
+use Illuminate\Contracts\Validation\Rule;
 use Illuminate\Database\Eloquent\Model;
 
 /**
@@ -19,7 +20,6 @@ class PlanCombination extends Model
      * {@inheritdoc}
      */
     protected $fillable = [
-        'plan_id',
         'tag',
         'country',
         'currency',
@@ -62,7 +62,14 @@ class PlanCombination extends Model
     {
         return [
             'plan_id' => 'required|exists:' . config('subby.tables.plans') . ',id',
-            'tag' => 'required|max:150|unique:' . config('subby.tables.plan_combinations') . ',tag',
+            'tag' => [
+                'required',
+                'alpha_dash',
+                'max:300',
+                Rule::unique(config('subby.tables.plan_combinations'))->where(function ($query) {
+                    return $query->where('id', '!=', $this->id);
+                }),
+            ],
             'country' => 'required|alpha|size:3',
             'price' => 'required|numeric',
             'signup_fee' => 'required|numeric',

--- a/src/Models/PlanCombination.php
+++ b/src/Models/PlanCombination.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bpuig\Subby\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Class Plan Combination
+ * @package Bpuig\Subby\Models
+ */
+class PlanCombination extends Model
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected $fillable = [
+        'tag',
+        'country',
+        'currency',
+        'price',
+        'signup_fee',
+        'invoice_period',
+        'invoice_interval'
+    ];
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $casts = [
+        'tag' => 'string',
+        'country' => 'string',
+        'currency' => 'string',
+        'price' => 'float',
+        'signup_fee' => 'float',
+        'invoice_period' => 'integer',
+        'invoice_interval' => 'string'
+    ];
+
+    /**
+     * Create a new Eloquent model instance.
+     *
+     * @param array $attributes
+     */
+    public function __construct(array $attributes = [])
+    {
+        parent::__construct($attributes);
+
+        $this->setTable(config('subby.tables.plan_combinations'));
+    }
+
+    /**
+     * Get validation rules
+     * @return string[]
+     */
+    public function getRules(): array
+    {
+        return [
+            'tag' => 'required|max:150|unique:' . config('subby.tables.plan_combinations') . ',tag',
+            'country' => 'required|alpha|size:3',
+            'price' => 'required|numeric',
+            'signup_fee' => 'required|numeric',
+            'currency' => 'required|alpha|size:3',
+            'invoice_period' => 'sometimes|integer|max:100000',
+            'invoice_interval' => 'sometimes|in:hour,day,week,month'
+        ];
+    }
+}

--- a/src/Models/PlanCombination.php
+++ b/src/Models/PlanCombination.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Bpuig\Subby\Models;
 
 use Bpuig\Subby\Traits\BelongsToPlan;
+use Bpuig\Subby\Traits\MorphsSchedules;
 use Illuminate\Contracts\Validation\Rule;
 use Illuminate\Database\Eloquent\Model;
 
@@ -14,7 +15,7 @@ use Illuminate\Database\Eloquent\Model;
  */
 class PlanCombination extends Model
 {
-    use BelongsToPlan;
+    use BelongsToPlan, MorphsSchedules;
 
     /**
      * {@inheritdoc}

--- a/src/Models/PlanCombination.php
+++ b/src/Models/PlanCombination.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Bpuig\Subby\Models;
 
+use Bpuig\Subby\Traits\BelongsToPlan;
 use Illuminate\Database\Eloquent\Model;
 
 /**
@@ -12,10 +13,13 @@ use Illuminate\Database\Eloquent\Model;
  */
 class PlanCombination extends Model
 {
+    use BelongsToPlan;
+
     /**
      * {@inheritdoc}
      */
     protected $fillable = [
+        'plan_id',
         'tag',
         'country',
         'currency',
@@ -57,6 +61,7 @@ class PlanCombination extends Model
     public function getRules(): array
     {
         return [
+            'plan_id' => 'required|exists:' . config('subby.tables.plans') . ',id',
             'tag' => 'required|max:150|unique:' . config('subby.tables.plan_combinations') . ',tag',
             'country' => 'required|alpha|size:3',
             'price' => 'required|numeric',
@@ -65,5 +70,16 @@ class PlanCombination extends Model
             'invoice_period' => 'sometimes|integer|max:100000',
             'invoice_interval' => 'sometimes|in:hour,day,week,month'
         ];
+    }
+
+    /**
+     * Get plan combination by the given tag.
+     *
+     * @param string $tag
+     * @return null|$this
+     */
+    static public function getByTag(string $tag): ?PlanCombination
+    {
+        return static::where('tag', $tag)->first();
     }
 }

--- a/src/Models/PlanSubscription.php
+++ b/src/Models/PlanSubscription.php
@@ -109,7 +109,7 @@ class PlanSubscription extends Model
             ],
             'subscriber_id' => 'required|integer',
             'subscriber_type' => 'required|string|max:150',
-            'plan_id' => 'required|integer|exists:' . config('subby.tables.plans') . ',id',
+            'plan_id' => 'required|exists:' . config('subby.tables.plans') . ',id',
             'name' => 'required|string|max:150',
             'description' => 'nullable|string|max:32768',
             'price' => 'required|numeric',

--- a/src/SubbyServiceProvider.php
+++ b/src/SubbyServiceProvider.php
@@ -56,12 +56,14 @@ class SubbyServiceProvider extends ServiceProvider
             __DIR__ . '/../database/migrations/create_plan_subscriptions_table.php' => database_path('migrations/' . date('Y_m_d_His', time() + 2) . '_create_plan_subscriptions_table.php'),
             __DIR__ . '/../database/migrations/create_plan_subscription_features_table.php' => database_path('migrations/' . date('Y_m_d_His', time() + 3) . '_create_plan_subscription_features_table.php'),
             __DIR__ . '/../database/migrations/create_plan_subscription_usage_table.php' => database_path('migrations/' . date('Y_m_d_His', time() + 4) . '_create_plan_subscription_usage_table.php'),
-            __DIR__ . '/../database/migrations/create_plan_subscription_schedules_table.php' => database_path('migrations/' . date('Y_m_d_His', time() + 5) . '_create_plan_subscription_schedules_table.php')
+            __DIR__ . '/../database/migrations/create_plan_subscription_schedules_table.php' => database_path('migrations/' . date('Y_m_d_His', time() + 5) . '_create_plan_subscription_schedules_table.php'),
+            __DIR__ . '/../database/migrations/create_plan_combinations_table.php' => database_path('migrations/' . date('Y_m_d_His', time() + 6) . 'create_plan_combinations_table.php')
         ], 'subby.migrations');
 
         $this->publishes([
             __DIR__ . '/../database/migrations/dev/alter_plan_subscriptions_table.php' => database_path('migrations/' . date('Y_m_d_His', time()) . '_alter_plan_subscriptions_table.php'),
-            __DIR__ . '/../database/migrations/dev/alter_plan_subscription_schedules_table.php' => database_path('migrations/' . date('Y_m_d_His', time() + 1) . '_alter_plan_subscription_schedules_table.php')
+            __DIR__ . '/../database/migrations/dev/alter_plan_subscription_schedules_table.php' => database_path('migrations/' . date('Y_m_d_His', time() + 1) . '_alter_plan_subscription_schedules_table.php'),
+            __DIR__ . '/../database/migrations/create_plan_combinations_table.php' => database_path('migrations/' . date('Y_m_d_His', time() + 6) . 'create_plan_combinations_table.php')
         ], 'subby.migrations.dev');
     }
 

--- a/src/SubbyServiceProvider.php
+++ b/src/SubbyServiceProvider.php
@@ -57,13 +57,13 @@ class SubbyServiceProvider extends ServiceProvider
             __DIR__ . '/../database/migrations/create_plan_subscription_features_table.php' => database_path('migrations/' . date('Y_m_d_His', time() + 3) . '_create_plan_subscription_features_table.php'),
             __DIR__ . '/../database/migrations/create_plan_subscription_usage_table.php' => database_path('migrations/' . date('Y_m_d_His', time() + 4) . '_create_plan_subscription_usage_table.php'),
             __DIR__ . '/../database/migrations/create_plan_subscription_schedules_table.php' => database_path('migrations/' . date('Y_m_d_His', time() + 5) . '_create_plan_subscription_schedules_table.php'),
-            __DIR__ . '/../database/migrations/create_plan_combinations_table.php' => database_path('migrations/' . date('Y_m_d_His', time() + 6) . 'create_plan_combinations_table.php')
+//            __DIR__ . '/../database/migrations/create_plan_combinations_table.php' => database_path('migrations/' . date('Y_m_d_His', time() + 6) . '_create_plan_combinations_table.php')
         ], 'subby.migrations');
 
         $this->publishes([
             __DIR__ . '/../database/migrations/dev/alter_plan_subscriptions_table.php' => database_path('migrations/' . date('Y_m_d_His', time()) . '_alter_plan_subscriptions_table.php'),
             __DIR__ . '/../database/migrations/dev/alter_plan_subscription_schedules_table.php' => database_path('migrations/' . date('Y_m_d_His', time() + 1) . '_alter_plan_subscription_schedules_table.php'),
-            __DIR__ . '/../database/migrations/create_plan_combinations_table.php' => database_path('migrations/' . date('Y_m_d_His', time() + 6) . 'create_plan_combinations_table.php')
+            __DIR__ . '/../database/migrations/create_plan_combinations_table.php' => database_path('migrations/' . date('Y_m_d_His', time() + 2) . '_create_plan_combinations_table.php')
         ], 'subby.migrations.dev');
     }
 

--- a/src/SubbyServiceProvider.php
+++ b/src/SubbyServiceProvider.php
@@ -57,7 +57,7 @@ class SubbyServiceProvider extends ServiceProvider
             __DIR__ . '/../database/migrations/create_plan_subscription_features_table.php' => database_path('migrations/' . date('Y_m_d_His', time() + 3) . '_create_plan_subscription_features_table.php'),
             __DIR__ . '/../database/migrations/create_plan_subscription_usage_table.php' => database_path('migrations/' . date('Y_m_d_His', time() + 4) . '_create_plan_subscription_usage_table.php'),
             __DIR__ . '/../database/migrations/create_plan_subscription_schedules_table.php' => database_path('migrations/' . date('Y_m_d_His', time() + 5) . '_create_plan_subscription_schedules_table.php'),
-//            __DIR__ . '/../database/migrations/create_plan_combinations_table.php' => database_path('migrations/' . date('Y_m_d_His', time() + 6) . '_create_plan_combinations_table.php')
+            __DIR__ . '/../database/migrations/create_plan_combinations_table.php' => database_path('migrations/' . date('Y_m_d_His', time() + 6) . '_create_plan_combinations_table.php')
         ], 'subby.migrations');
 
         $this->publishes([

--- a/src/Traits/HasSubscriptions.php
+++ b/src/Traits/HasSubscriptions.php
@@ -114,7 +114,7 @@ trait HasSubscriptions
      * Subscribe subscriber to a new plan.
      *
      * @param string $tag Identifier tag for the subscription
-     * @param \Bpuig\Subby\Models\Plan $plan Related plan
+     * @param \Bpuig\Subby\Models\Plan|\Bpuig\Subby\Models\PlanCombination $planCombination Plan pricing and invoice data
      * @param string|null $name Human readable name for your subscriber's subscription
      * @param string|null $description Description for the subscription
      * @param \Carbon\Carbon|null $startDate When will the subscription start
@@ -122,9 +122,11 @@ trait HasSubscriptions
      * @return \Illuminate\Database\Eloquent\Model
      * @throws \Exception
      */
-    public function newSubscription(?string $tag, Plan|PlanCombination $plan, ?string $name = null, ?string $description = null, ?Carbon $startDate = null, $paymentMethod = 'free')
+    public function newSubscription(?string $tag, Plan|PlanCombination $planCombination, ?string $name = null, ?string $description = null, ?Carbon $startDate = null, $paymentMethod = 'free')
     {
         $tag = $tag ?? config('subby.main_subscription_tag');
+
+        $plan = ($planCombination instanceof PlanCombination) ? $planCombination->plan : $planCombination;
 
         $subscriptionPeriod = new SubscriptionPeriod($plan, $startDate ?? now());
 
@@ -136,15 +138,15 @@ trait HasSubscriptions
                 'name' => $name,
                 'description' => $description,
                 'plan_id' => $plan->id,
-                'price' => $plan->price,
-                'currency' => $plan->currency,
+                'price' => $planCombination->price,
+                'currency' => $planCombination->currency,
                 'tier' => $plan->tier,
                 'trial_interval' => $plan->trial_interval,
                 'trial_period' => $plan->trial_period,
                 'grace_interval' => $plan->grace_interval,
                 'grace_period' => $plan->grace_period,
-                'invoice_interval' => $plan->invoice_interval,
-                'invoice_period' => $plan->invoice_period,
+                'invoice_interval' => $planCombination->invoice_interval,
+                'invoice_period' => $planCombination->invoice_period,
                 'payment_method' => $paymentMethod,
                 'trial_ends_at' => $subscriptionPeriod->getTrialEndDate(),
                 'starts_at' => $subscriptionPeriod->getStartDate(),

--- a/src/Traits/MorphsSchedules.php
+++ b/src/Traits/MorphsSchedules.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Bpuig\Subby\Traits;
+
+trait MorphsSchedules
+{
+    /**
+     * Get all schedules.
+     */
+    public function schedules()
+    {
+        return $this->morphMany(config('subby.models.plan_subscription_schedule'), 'scheduleable');
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -38,6 +38,7 @@ class TestCase extends \Orchestra\Testbench\TestCase
             // Database Tables
             'tables' => [
                 'plans' => 'plans',
+                'plan_combinations' => 'plan_combinations',
                 'plan_features' => 'plan_features',
                 'plan_subscriptions' => 'plan_subscriptions',
                 'plan_subscription_features' => 'plan_subscription_features',
@@ -47,6 +48,7 @@ class TestCase extends \Orchestra\Testbench\TestCase
             // Models
             'models' => [
                 'plan' => \Bpuig\Subby\Models\Plan::class,
+                'plan_combination' => \Bpuig\Subby\Models\PlanCombination::class,
                 'plan_feature' => \Bpuig\Subby\Models\PlanFeature::class,
                 'plan_subscription' => \Bpuig\Subby\Models\PlanSubscription::class,
                 'plan_subscription_feature' => \Bpuig\Subby\Models\PlanSubscriptionFeature::class,
@@ -123,6 +125,15 @@ class TestCase extends \Orchestra\Testbench\TestCase
             new PlanFeature(['tag' => 'social_profiles', 'name' => 'Social profiles available', 'value' => 3, 'sort_order' => 1]),
             new PlanFeature(['tag' => 'posts_per_social_profile', 'name' => 'Scheduled posts per profile', 'value' => 30, 'sort_order' => 10, 'resettable_period' => 1, 'resettable_interval' => 'month']),
             new PlanFeature(['tag' => 'analytics', 'name' => 'Analytics', 'value' => false, 'sort_order' => 15])
+        ]);
+
+        $this->testPlanBasic->combinations()->create([
+            'tag' => 'test',
+            'country' => 'ESP',
+            'currency' => 'EUR',
+            'price' => 99.99,
+            'invoice_period' => 1,
+            'invoice_interval' => 'year'
         ]);
 
         // Create a Pro plan

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -128,7 +128,7 @@ class TestCase extends \Orchestra\Testbench\TestCase
         ]);
 
         $this->testPlanBasic->combinations()->create([
-            'tag' => 'test',
+            'tag' => 'test-plan-basic-esp-eur-1-year',
             'country' => 'ESP',
             'currency' => 'EUR',
             'price' => 99.99,

--- a/tests/Unit/PlanCombinationTest.php
+++ b/tests/Unit/PlanCombinationTest.php
@@ -1,0 +1,42 @@
+<?php
+
+
+namespace Bpuig\Subby\Tests\Unit;
+
+
+use Bpuig\Subby\Tests\TestCase;
+
+class PlanCombinationTest extends TestCase
+{
+    /**
+     * Test Plan Combination creation with already existing tag in database
+     */
+    public function testUnableToCreatePlanCombinationWithExistingTag()
+    {
+        $this->expectExceptionMessage('UNIQUE constraint failed: ' . config('subby.tables.plan_combinations') . '.tag');
+        $this->testPlanBasic->combinations()->create([
+            'tag' => 'test-plan-basic-esp-eur-1-year',
+            'country' => 'ESP',
+            'currency' => 'EUR',
+            'price' => 99.99,
+            'invoice_period' => 1,
+            'invoice_interval' => 'year'
+        ]);
+    }
+
+    /**
+     * Test Plan Combination creation with already existing content in database
+     */
+    public function testUnableToCreatePlanCombinationWithExistingContent()
+    {
+        $this->expectExceptionMessage('UNIQUE constraint failed: ' . config('subby.tables.plan_combinations') . '.country, ' . config('subby.tables.plan_combinations') . '.currency, ' . config('subby.tables.plan_combinations') . '.invoice_period, ' . config('subby.tables.plan_combinations') . '.invoice_interval');
+        $this->testPlanBasic->combinations()->create([
+            'tag' => 'test-2',
+            'country' => 'ESP',
+            'currency' => 'EUR',
+            'price' => 99.99,
+            'invoice_period' => 1,
+            'invoice_interval' => 'year'
+        ]);
+    }
+}

--- a/tests/Unit/PlanSubscriptionScheduleTest.php
+++ b/tests/Unit/PlanSubscriptionScheduleTest.php
@@ -4,6 +4,7 @@
 namespace Bpuig\Subby\Tests\Unit;
 
 
+use Bpuig\Subby\Models\Plan;
 use Bpuig\Subby\Models\PlanSubscriptionSchedule;
 use Bpuig\Subby\Tests\TestCase;
 use Carbon\Carbon;
@@ -22,7 +23,7 @@ class PlanSubscriptionScheduleTest extends TestCase
         $date = Carbon::now()->add(5, 'day');
         $this->testUser->subscription('main')->toPlan($this->testPlanPro)->onDate($date)->setSchedule();
 
-        $schedule = PlanSubscriptionSchedule::where('plan_id', $this->testPlanPro->id)
+        $schedule =$this->testPlanPro->schedules()
             ->where('subscription_id', $this->testUser->subscription('main')->id)
             ->where('scheduled_at', $date->format('Y-m-d H:i:s'))
             ->first();
@@ -45,7 +46,7 @@ class PlanSubscriptionScheduleTest extends TestCase
     public function testScheduleCreationWithoutPlan()
     {
         $date = Carbon::now()->add(5, 'day');
-        $this->expectExceptionMessage('Scheduled plan is empty.');
+        $this->expectExceptionMessage('Scheduled plan/combination is empty.');
         $this->testUser->subscription('main')->onDate($date)->setSchedule();
     }
 
@@ -55,7 +56,7 @@ class PlanSubscriptionScheduleTest extends TestCase
     public function testScheduleCreationWithWrongPlan()
     {
         $date = Carbon::now()->add(5, 'day');
-        $this->expectExceptionMessage('Plan is not a valid Eloquent Plan Model instance.');
+        $this->expectExceptionMessage('Argument #1 ($planCombination) must be of type Bpuig\Subby\Models\Plan|Bpuig\Subby\Models\PlanCombination');
         $this->testUser->subscription('main')->toPlan('test')->onDate($date)->setSchedule();
     }
 

--- a/tests/Unit/PlanSubscriptionTest.php
+++ b/tests/Unit/PlanSubscriptionTest.php
@@ -40,6 +40,15 @@ class PlanSubscriptionTest extends TestCase
     }
 
     /**
+     * Test making a Subscription to a combination
+     */
+    public function testSubscriptionToAPlanCombination()
+    {
+        $this->testUser->newSubscription('combination-test', $this->testPlanBasic->combinations()->first(), 'Test a combination subscription');
+        $this->assertNotNull($this->testUser->subscription('combination-test'));
+    }
+
+    /**
      * Test plan change
      */
     public function testPlanChange()


### PR DESCRIPTION
## Status
**IN DEVELOPMENT**

## Migrations
YES

## Description
This pull requests adds the ability to have multiple combinations for a plan, per country, currency and interval period. So plan does not have to be duplicated for every country combination.

Current `Plan` price, interval, etc will be kept as a fallback and also for the people who does not want to use combinations.

## Todos
- [x] Tests
- [x] Documentation


## Deploy Notes
This will be in the new `v6`, so migrate following the instructions like in a new release.


## Impacted Areas in Application
List general components of the application that this PR will affect:

* Plans
* Plan Subscriptions
* Plan Combinations
