### PR TITLE
Plan > combinations . config

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -8,7 +8,7 @@ return [
     // Database Tables
     'tables' => [
         'plans' => 'plans',
-        'plan_combinations' => 'plan_combinations',
+        'plan_combination' => 'plan_combinations',
         'plan_features' => 'plan_features',
         'plan_subscriptions' => 'plan_subscriptions',
         'plan_subscription_features' => 'plan_subscription_features',
@@ -19,7 +19,7 @@ return [
     // Models
     'models' => [
         'plan' => \Bpuig\Subby\Models\Plan::class,
-        'plan_combinations' => \Bpuig\Subby\Models\PlanCombination::class,
+        'plan_combination' => \Bpuig\Subby\Models\PlanCombination::class,
         'plan_feature' => \Bpuig\Subby\Models\PlanFeature::class,
         'plan_subscription' => \Bpuig\Subby\Models\PlanSubscription::class,
         'plan_subscription_feature' => \Bpuig\Subby\Models\PlanSubscriptionFeature::class,

--- a/config/config.php
+++ b/config/config.php
@@ -8,7 +8,7 @@ return [
     // Database Tables
     'tables' => [
         'plans' => 'plans',
-        'plan_combination' => 'plan_combinations',
+        'plan_combinations' => 'plan_combinations',
         'plan_features' => 'plan_features',
         'plan_subscriptions' => 'plan_subscriptions',
         'plan_subscription_features' => 'plan_subscription_features',


### PR DESCRIPTION
The config information in the combinations method is incorrect.

\Bpuig\Subby\Models\Plan > combinations 


    /**
     * The plan may have many combinations.
     *
     * @return \Illuminate\Database\Eloquent\Relations\HasMany
     */
    public function combinations(): HasMany
    {
        return $this->hasMany(config('subby.models.plan_combination'), 'plan_id', 'id');
    }

## Status
**READY/IN DEVELOPMENT/HOLD**

## Migrations
YES | NO

## Description
A few sentences describing the overall goals of the pull request's commits.

## Todos
- [ ] Tests
- [ ] Documentation


## Deploy Notes
Notes regarding deployment the contained body of work.  These should note any
db migrations, etc.


## Impacted Areas in Application
List general components of the application that this PR will affect:

* 
