### PR TITLE
Fix new subscription with plan combination

### DIFF
--- a/src/Services/SubscriptionPeriod.php
+++ b/src/Services/SubscriptionPeriod.php
@@ -23,7 +23,7 @@ class SubscriptionPeriod
     protected $plan;
     protected $startDate;
 
-    public function __construct(Plan $plan, Carbon $startDate)
+    public function __construct(Plan|PlanCombination $plan, Carbon $startDate)
     {
         $this->plan = $plan;
         $this->startDate = $startDate;

--- a/src/Traits/HasSubscriptions.php
+++ b/src/Traits/HasSubscriptions.php
@@ -128,7 +128,7 @@ trait HasSubscriptions
 
         $plan = ($planCombination instanceof PlanCombination) ? $planCombination->plan : $planCombination;
 
-        $subscriptionPeriod = new SubscriptionPeriod($plan, $startDate ?? now());
+        $subscriptionPeriod = new SubscriptionPeriod($planCombination, $startDate ?? now());
 
         try {
             $this->subscription($tag);


### PR DESCRIPTION
error: the subscription expiry time (ends_at) of the plan defined for the member was defined according to the main plan (table.plans) invoiceperiod and invoice interval.
example
main plan 1 year
selected plan 3 years (combination)
ends_at = now + 1year :(


fix: the subscription expiry time (ends_at) of the plan defined for the member is now defined according to the selected combination plan invoice period and invoice interval.
example
main plan 1 year
selected plan 3 years (combination)
ends_at = now + 3year :)